### PR TITLE
Skip existing deps that are up-to-date + module listing

### DIFF
--- a/apertium-get
+++ b/apertium-get
@@ -85,6 +85,19 @@ make_dep () {
     )
 }
 
+is_dep_updated () {
+    local -r dep=$1
+    local -r dir=$(dir_of_dep "${dep}")
+    if [[ -d ${dir} ]]; then
+        if [[ -z $(svn status -qu "${dir}") ]]; then
+            echo "yes"
+            return 0
+        fi
+    fi
+
+    echo "no"
+}
+
 get_dep () {
     local -r dep=$1
     local -r dir=$(dir_of_dep "${dep}")
@@ -115,8 +128,14 @@ in_array () {
 
 get_pair () {
     local -r keep_going=$1
-    local -r pair=apertium-${2##apertium-}
-    local -r skip="${@:3}"   # intentionally assigning array to string
+    local -r skip_if_up_to_date=$2
+    local -r pair=apertium-${3##apertium-}
+    local -r skip="${@:4}"   # intentionally assigning array to string
+
+    if [[ ${skip_if_up_to_date} == true && $(is_dep_updated "${pair}") == "yes" ]]; then
+        printf "Existing pair %s is already up to date. Skipping build step.\n" "${pair}"
+        return 0
+    fi
 
     get_dep "${pair}"
     # Mac has ancient bash, so no declare -A for us
@@ -138,7 +157,7 @@ get_pair () {
 
     if [[ ${#deps[@]} -ne 0 ]]; then
         for dep in "${deps[@]}"; do
-            if ! get_data "${keep_going}" "${dep}"; then
+            if ! get_data "${skip_if_up_to_date}" "${keep_going}" "${dep}"; then
                 echo
                 echo "WARNING: Couldn't get dependency ${dep}; pair ${pair} might not get set up correctly."
                 echo
@@ -202,7 +221,8 @@ maybe_symlink_GTHOME () {
 
 get_data () {
     local -r keep_going=$1
-    local -r orglangs=$(split_org_langs "$2")
+    local -r skip_if_up_to_date=$2
+    local -r orglangs=$(split_org_langs "$3")
     local -r org=${orglangs%% *}
     local -r langs=${orglangs##* }
 
@@ -215,10 +235,15 @@ get_data () {
             get_dep gtcore
             make_dep gtcore
         fi
-        if get_dep "$2"; then
-            make_dep "$2"
+
+        if [[ ${skip_if_up_to_date} == true && $(is_dep_updated "$3") == "yes" ]]; then
+            printf "Dependency %s is up-to-date, skipping update and build.\n" "$3"
         else
-            return 1
+            if get_dep "$3"; then
+                make_dep "$3"
+            else
+                return 1
+            fi
         fi
     fi
 }
@@ -236,11 +261,15 @@ DESCRIPTION
        With the -l option, it will list available language pairs. Give
        one or more MODULE arguments to list only pairs in that SVN
        module (one of "trunk", "staging", "nursery", "incubator").
+       The same behavior can be invoked for language modules using -m.
 
 OPTIONS
        -h          display this help and exit
        -l          list available packages instead of setting up data
+       -m          list available language modules instead of setting up
+                   data
        -k          keep going even if a dependency fails
+       -s          skip the build step for up-to-date dependencies/pairs
        -x DEP      skip data dependency DEP (useful if DEP is installed
                    through a package manager); may be specified multiple
                    times
@@ -307,6 +336,33 @@ list_pairs () {
     done
 }
 
+list_language_modules() {
+    local -a modules=("$@")
+    local module
+
+    # Defaulting to all modules:
+    if [[ ${#modules[@]} -eq 0 ]]; then
+        modules=( ${lmodules[@]} )
+    fi
+    # Sanity-check input:
+    for module in "${modules[@]}"; do
+        if ! is_in "${module}" "${lmodules[@]}"; then
+            echo "ERROR: '${module}' not recognised as an SVN language module module"'!' >&2
+            echo >&2
+            show_help >&2
+            exit 1
+        fi
+    done
+
+    local url=
+    for module in "${modules[@]}"; do
+        echo "# Language modules in ${module}:"
+        url="${svnroot}${module}/"
+        svn ls "${url}" | grep '^apertium-[[:alpha:]]\{2,3\}/*$'
+        echo
+    done
+}
+
 sanity_check () {
     if ! command -V svn >/dev/null; then
         cat >&2 <<EOF
@@ -327,10 +383,12 @@ EOF
 
 main () {
     sanity_check
-    local do_list=false
+    local do_list_pairs=false
     local keep_going=false
+    local do_list_language_modules=false
+    local skip_if_up_to_date=false
     local -a skip=()
-    while getopts ":hklx:" opt; do
+    while getopts ":hklmsx:" opt; do
         case "$opt" in
             h)
                 show_help
@@ -340,10 +398,16 @@ main () {
                 skip+=( "${OPTARG}" )
                 ;;
             l)
-                do_list=true
+                do_list_pairs=true
+                ;;
+            m)
+                do_list_language_modules=true
                 ;;
             k)
                 keep_going=true
+                ;;
+            s)
+                skip_if_up_to_date=true
                 ;;
             \?)
                 echo "ERROR: Invalid option: -$OPTARG" >&2
@@ -355,8 +419,10 @@ main () {
     done
     shift "$((OPTIND-1))"
 
-    if ${do_list}; then
+    if ${do_list_pairs}; then
         list_pairs "$@"
+    elif ${do_list_language_modules}; then
+        list_language_modules "$@"
     else
         if [[ $# -lt 1 ]]; then
             echo "ERROR: No language pair specified." >&2
@@ -365,7 +431,7 @@ main () {
             exit 1
         fi
         for d in "$@"; do
-            get_data "${keep_going}" "$d" "${skip[@]:-}"
+            get_data "${keep_going}" "${skip_if_up_to_date}" "$d" "${skip[@]:-}"
         done
     fi
 }

--- a/t/tests.sh
+++ b/t/tests.sh
@@ -22,8 +22,11 @@ diff <("${prog}" -? 2>&1) unarg.expected
 echo "List trunk …"
 diff <("${prog}" -l trunk) trunk.expected
 
-echo "Full listing should be big …"
+echo "Full pair listing should be big …"
 [[ $("${prog}" -l | wc -l) -ge 200 ]]
+
+echo "Full module listing should be fairly big …"
+[[ $("${prog}" -m | wc -l) -ge 100 ]]
 
 echo "Try to set up nno-nob …"
 (
@@ -32,6 +35,12 @@ echo "Try to set up nno-nob …"
     cd apertium-nno-nob
     make test >&2
 ) > nno-nob.log || ( cat nno-nob.log; exit 1 )
+
+echo "Try to set up nno-nob again (skipping build) …"
+(
+    cd "${tmp}"
+    "${prog}" -s nno-nob 2>&1 | grep -i skipping
+) > nno-nob.2.log || ( cat nno-nob.2.log; exit 1 )
 
 echo "Try to set up fr-es …"
 (

--- a/t/unarg.expected
+++ b/t/unarg.expected
@@ -11,11 +11,15 @@ DESCRIPTION
        With the -l option, it will list available language pairs. Give
        one or more MODULE arguments to list only pairs in that SVN
        module (one of "trunk", "staging", "nursery", "incubator").
+       The same behavior can be invoked for language modules using -m.
 
 OPTIONS
        -h          display this help and exit
        -l          list available packages instead of setting up data
+       -m          list available language modules instead of setting up
+                   data
        -k          keep going even if a dependency fails
+       -s          skip the build step for up-to-date dependencies/pairs
        -x DEP      skip data dependency DEP (useful if DEP is installed
                    through a package manager); may be specified multiple
                    times


### PR DESCRIPTION
This seems somewhat false-negative'y if a corresponding language module is updated but the pair isn't. ~~Any ideas to fix it?~~ added an option