### PR TITLE
Port to Python

### DIFF
--- a/apertium-get.py
+++ b/apertium-get.py
@@ -65,7 +65,7 @@ def possible_paths(dep):
         lang = dep.split("-")[1]
         return ["giella-" + lang, "lang-" + lang]
     if len(dep.split("-")) == 3:
-        ap, l1, l2 = dep.split("-")
+        _, l1, l2 = dep.split("-")
         return ["apertium-%s-%s" % (l1, l2), "apertium-%s-%s" % (l2, l1)]
     return [dep]
 
@@ -123,17 +123,16 @@ def get_deps(pair):
     global dep_status
     global dep_paths
     global dep_reqs
-    conf = open(dep_paths[pair] + "/configure.ac")
-    dep_list = AP_CHECK_LING.findall(conf.read())
-    conf.close()
-    dep_reqs[pair] = []
-    for n, dep in dep_list:
-        if dep not in dep_status:
-            dep_status[dep] = Status.NOT_STARTED
-        elif dep_status[dep] == Status.SKIPPED:
-            print("\nSkipping data %s as instructed.\n" % dep)
-            continue
-        dep_reqs[pair].append((dep, n))
+    with open(dep_paths[pair] + "/configure.ac") as conf:
+        dep_list = AP_CHECK_LING.findall(conf.read())
+        dep_reqs[pair] = []
+        for n, dep in dep_list:
+            if dep not in dep_status:
+                dep_status[dep] = Status.NOT_STARTED
+            elif dep_status[dep] == Status.SKIPPED:
+                print("\nSkipping data %s as instructed.\n" % dep)
+                continue
+            dep_reqs[pair].append((dep, n))
 
 
 def update(dep, skip_update):

--- a/apertium-get.py
+++ b/apertium-get.py
@@ -1,219 +1,244 @@
 #!/usr/bin/python3
 
-import requests, argparse, subprocess, os, re, sys
+import argparse
+import os
+import re
+import sys
+import urllib.request
+from subprocess import (
+    run,
+    check_call,
+    check_output,
+    STDOUT,
+    DEVNULL,
+    CalledProcessError,
+)
 
 ### Globals:
 
-gitroot  = 'https://raw.githubusercontent.com/apertium'
-pmodules = ['trunk', 'staging', 'nursery', 'incubator']
-lmodules = ['languages', 'incubator']
+pmodules = ["trunk", "staging", "nursery", "incubator"]
+lmodules = ["languages", "incubator"]
 
-svnroot_giella = 'https://victorio.uit.no/langtech/trunk'
+git_ssh = "git@github.com:"
+git_https = "https://github.com/"
 
-pair_urls = {}
-lang_urls = {}
-giella_urls = {}
-module_contents = {}
+apertium_git = "apertium/apertium-%s.git"
+giella_git = "giellalt/lang-%s.git"
+giella_core_git = "giellalt/giella-core.git"
+giella_shared_git = "giellalt/giella-shared.git"
 
-ap_check_ling = re.compile(r'AP_CHECK_LING\(\[(\d)\],\s+\[([\w-]+)\]\)', re.MULTILINE)
+NOT_STARTED = 0
+CLONED = 1
+PULLED = 2
+DONE = 3
+SKIPPED = 4
+FAILED = 5
+
+DEP_PATHS = {}
+# e.g. 'apertium-eng' -> '~/apertium-eng'
+
+DEP_STATUS = {}
+# e.g. 'apertium-spa' -> CLONED
+
+DEP_REQS = {}
+# e.g. 'apertium-tur-uzb' -> [(1, 'apertium-tur'), (2, 'apertium-uzb')]
+
+ap_check_ling = re.compile(r"AP_CHECK_LING\(\[(\d)\],\s+\[([\w-]+)\]", re.MULTILINE)
 # original pattern:
 # (awk -F'[][[:space:]]+' '/^ *AP_CHECK_LING\(/ && $2 && $4 {print $2, $4}' "${pair}"/configure.ac)
 
+
 def get_output(command, dirname=None):
-    return subprocess.check_output(command, cwd=dirname, stderr=subprocess.STDOUT,
-                                   universal_newlines=True)
+    return check_output(command, cwd=dirname, stderr=STDOUT, universal_newlines=True)
+
+
 def run_command(command, dirname=None, env=None):
-    subprocess.check_call(command, cwd=dirname, stdout=None, stderr=None, env=env)
+    check_call(command, cwd=dirname, stdout=None, stderr=None, env=env)
 
-def get_urls():
-    global pair_urls
-    global lang_urls
-    global giella_urls
-    global module_contents
 
-    for module in list(set(pmodules + lmodules)):
-        module_contents[module] = []
-        req = requests.get('%s/apertium-%s/master/.gitmodules' % (gitroot, module))
-        if req.status_code != 200:
-            #error?
-            continue
-        for ln in req.text.splitlines():
-            if ln.startswith('\turl = '):
-                url = ln.split()[-1]
-                code = url.split('apertium-')[-1][:-4]
-                # e.g. 'git@github.com:apertium/apertium-fin.git' -> 'fin'
-                if '-' in code:
-                    pair_urls[code] = url
-                else:
-                    lang_urls[code] = url
-                module_contents[module].append(code)
-    req = requests.get(svnroot_giella + '/langs/')
-    if req.status_code != 200:
-        #error?
-        return
-    for ln in req.text.splitlines():
-        if '<li><a' in ln and '..' not in ln:
-            code = ln.split('"')[1][:-1]
-            # e.g. '<li><a href="vot/">vot/</a></li>' -> 'vot'
-            url = svnroot_giella + '/langs/' + code
-            giella_urls[code] = url
+def possible_paths(dep):
+    if dep.startswith("lang-"):
+        lang = dep.split("-")[1]
+        return ["giella-" + lang, "lang-" + lang]
+    if len(dep.split("-")) == 3:
+        ap, l1, l2 = dep.split("-")
+        return ["apertium-%s-%s" % (l1, l2), "apertium-%s-%s" % (l2, l1)]
+    return [dep]
 
-def dir_of_dep(dep):
-    if dep.startswith('giella-'):
-        return 'langs/' + dep[7:]
+
+def find_or_clone(dep, depth, use_https=False):
+    for name in possible_paths(dep):
+        pth = os.getcwd() + "/" + name
+        if os.path.isdir(pth + "/.git"):
+            DEP_PATHS[dep] = pth
+            DEP_STATUS[dep] = CLONED
+            return
+    dirname = None
+    alt_url = None
+    code = dep.split("-", 1)[1]
+    cmd = ["git", "clone"]
+    if depth > 0:
+        cmd += ["--depth", str(depth)]
+
+    url = git_https if use_https else git_ssh
+    if dep == "giella-core":
+        url += giella_core_git
+    elif dep == "giella-shared":
+        url += giella_shared_git
+    elif dep.startswith("lang-"):
+        dirname = "giella-" + code
+        url += giella_git % code
+    elif "-" in code:
+        alt_code = "-".join(reversed(code.split("-")))
+        alt_url = url + (apertium_git % alt_code)
+        url += apertium_git % code
     else:
-        return dep
+        url += apertium_git % code
+    cmd.append(url)
 
-def bins_of_dep(dep):
-    if dep.startswith('giella-'):
-        return 'langs/%s/tools/mt/apertium' % dep[7:]
-    else:
-        return dep
-
-def make_dep(dep):
-    dirname = dir_of_dep(dep)
-    env = os.environ.copy()
-    env['GTHOME'] = os.getcwd()
-    env['GTCORE'] = os.getcwd() + '/gtcore'
-    # Let cwd be GTHOME from here on in; langs should exist under this dir:
-    print(dirname)
-    run_command(['./autogen.sh'], dirname, env)
-    if dep.startswith('giella-'):
-        run_command(['./configure', '--enable-apertium', '--with-hfst', '--enable-syntax'], dirname, env)
-        env['V'] = '1'
-        run_command(['make'], dirname, env)
-    elif dep == 'gtcore':
-        run_command(['./configure'], dirname, env)
-        run_command(['make', '-j3'], dirname, env)
-    else:
-        run_command(['make', '-j3'], dirname, env)
-
-def is_dep_updated(dep):
-    dirname = dir_of_dep(dep)
-    if os.path.isdir(dirname):
-        if os.path.isdir(dirname + '/.git'):
-            return get_output(['git', 'fetch', '--dry-run'], dirname) == ''
-        return get_output(['svn', 'status', '-qu', dirname]) == ''
-    return False
-
-def get_dep(depth, dep):
-    dirname = dir_of_dep(dep)
-    if os.path.isdir(dirname):
-        print('Updating existing %s (%s)' % (dirname, os.getcwd()))
-        cmd = ['svn', 'up']
-        if os.path.isdir(dirname + '/.git'):
-            cmd = ['git', 'pull']
-        run_command(cmd, dirname)
-    else:
-        if dep == 'gtcore':
-            run_command(['svn', 'checkout', svnroot_giella + '/gtcore', dirname])
-        if dep.startswith('giella-'):
-            url = giella_urls[dep.split('-', 1)[1]]
-            run_command(['svn', 'checkout', url, dirname])
+    if dirname:
+        cmd.append(dirname)
+    try:
+        run_command(cmd)
+        DEP_PATHS[dep] = dirname or (
+            os.getcwd() + "/" + url.split("/")[-1].split(".")[0]
+        )
+        DEP_STATUS[dep] = PULLED
+    except CalledProcessError:
+        if alt_url:
+            name = alt_url.split("/")[-1].split(".")[0]
+            run_command(cmd[:-1] + [alt_url])
+            print("\nWARNING: %s is actually named %s\n" % (dep, name))
+            DEP_PATHS[dep] = os.getcwd() + "/" + name
+            DEP_STATUS[dep] = PULLED
         else:
-            name = dirname.split('-', 1)[1]
-            url = pair_urls[name] if '-' in name else lang_urls[name]
-            cmd = ['git', 'clone']
-            if depth > 0:
-                cmd += ['--depth', str(depth)]
-            run_command(cmd + [url, dirname])
+            raise
 
-def get_pair(depth, keep_going, skip_if_up_to_date, pair, skip):
-    if skip_if_up_to_date and is_dep_updated(pair):
-        print('Existing pair %s is already up to date. Skipping build step.' % pair)
-        return
 
-    get_dep(depth, pair)
-    deps = []
-    conf = open(pair + '/configure.ac')
+def get_deps(pair):
+    global DEP_STATUS
+    global DEP_PATHS
+    global DEP_REQS
+    conf = open(DEP_PATHS[pair] + "/configure.ac")
     dep_list = ap_check_ling.findall(conf.read())
     conf.close()
+    DEP_REQS[pair] = []
     for n, dep in dep_list:
-        org, lang = dep.split('-', 1)
-        if lang in skip:
-            print('\nSkipping data %s as instructed.\n' % lang)
-        else:
-            deps.append((dep, n))
+        if dep not in DEP_STATUS:
+            DEP_STATUS[dep] = NOT_STARTED
+        elif DEP_STATUS[dep] == SKIPPED:
+            print("\nSkipping data %s as instructed.\n" % dep)
+            continue
+        DEP_REQS[pair].append((dep, n))
 
-    cmd = ['./autogen.sh']
-    for dep, n in deps:
-        try:
-            get_data(depth, skip_if_up_to_date, keep_going, dep, skip)
-        except subprocess.CalledProcessError:
-            print("\nWARNING: Couldn't get dependency %s; pair %s might not get set up correctly.\n" % (dep, pair))
-            if keep_going:
-                print('WARNING: Continuing on as if nothing happened ...\n')
-            else:
-                sys.exit(1)
-        binsdir = bins_of_dep(dep)
-        cmd.append('--with-lang%s=../%s' % (n, binsdir))
 
-    run_command(cmd, dirname=pair)
-    run_command(['make', '-j3'], dirname=pair)
+def update(dep, skip_update):
+    dirname = DEP_PATHS[dep]
+    if skip_update:
+        if get_output(["git", "fetch", "--dry-run"], dirname) == "":
+            DEP_STATUS[dep] = DONE
+            return
+    run_command(["git", "pull"], dirname)
+    DEP_STATUS[dep] = PULLED
+
+
+def build(dep):
+    dirname = DEP_PATHS[dep]
+    env = None
+    if dep.startswith("lang-"):
+        env = os.environ.copy()
+        if "GIELLA_CORE" not in env:
+            env["GIELLA_CORE"] = DEP_PATHS.get("giella-core", "")
+        if "GIELLA_SHARED" not in env:
+            env["GIELLA_SHARED"] = DEP_PATHS.get("giella-shared", "")
+
+    run_command(["autoreconf", "-fvi"], dirname=dirname, env=env)
+
+    cmd = ["./configure"]
+    if dep.startswith("lang-"):
+        cmd += ["--enable-apertium", "--with-hfst", "--enable-syntax"]
+    for name, idx in DEP_REQS[dep]:
+        pth = DEP_PATHS[name]
+        if name.startswith("lang-"):
+            pth += "/tools/mt/apertium"
+        cmd.append("--with-lang%s=%s" % (idx, pth))
+    run_command(cmd, dirname=dirname, env=env)
+
+    run_command(["make", "-j3"], dirname=dirname, env=env)
+
+    DEP_STATUS[dep] = DONE
+
+
+def list_pairs(module, getting_pairs):
+    print("# %s in %s:" % (("Pairs" if getting_pairs else "Language modules"), module))
+    submodule_url = (
+        "https://raw.githubusercontent.com/apertium/apertium-%s/master/.gitmodules"
+    )
+    req = urllib.request.urlopen(submodule_url % module)
+    for ln in req.read().decode("utf-8").splitlines():
+        if ln.startswith("\turl = "):
+            url = ln.split()[-1]
+            code = url.split("apertium-")[-1][:-4]
+            # e.g. 'git@github.com:apertium/apertium-fin.git' -> 'fin'
+            if ("-" in code) == getting_pairs:
+                print(code)
+
+
+def normalize_name(name):
+    if (
+        name.startswith("apertium-")
+        or name.startswith("lang-")
+        or name in ["giella-core", "giella-shared"]
+    ):
+        return name
+    elif name.startswith("giella-"):
+        return "lang-" + name.split("-")[1]
+    else:
+        return "apertium-" + name
+
+
+def get_all_status(status):
+    return [dep for dep in DEP_STATUS if DEP_STATUS[dep] == status]
+
+
+def error_on_dep(dep, keep_going):
+    global DEP_STATUS
+    if keep_going:
+        DEP_STATUS[dep] = FAILED
+        print("\nContinuing...\n")
+        if dep.startswith("giella-"):
+            print("WARNING: Giella language modules may fail to build correctly\n")
+        elif len(dep.split("-")) == 2:
+            print(
+                "WARNING: pairs dependent on this module may fail to build correctly\n"
+            )
+    else:
+        sys.exit(1)
+
+
+def try_to_clone(dep, depth, keep_going):
     try:
-        subprocess.check_call(['make', 'test'], cwd=pair, stdout=None, stderr=None)
-    except subprocess.CalledProcessError:
-        print("make test failed, but that's probably fine.")
+        find_or_clone(dep, depth)
+        get_deps(dep)
+    except CalledProcessError:
+        print("\nUnable to clone %s.\n" % dep)
+        error_on_dep(dep, keep_going)
 
-    print('''
 
-All done!
+def try_to_build(dep, keep_going):
+    try:
+        build(dep)
+    except CalledProcessError:
+        print("\nUnable to build %s.\n" % dep)
+        error_on_dep(dep, keep_going)
 
-You can now "cd ${pair}" or one of the dependencies, edit some files
-and type "make -j3 langs" to compile again.
-
-''')
-
-def maybe_symlink_GTHOME(dirname):
-    if os.path.isdir(dirname):
-        print('\nFound %s here, using that.\n' % dirname)
-    elif 'GTHOME' not in os.environ:
-        print('\nGTHOME unset; will have to build %s without it.\n' % dirname)
-    elif os.path.isdir(os.environ['GTHOME'] + '/' + dirname):
-        print('Found %s in your $GTHOME, symlinking to that to avoid recompilation.\n' % dirname)
-        if not os.path.isdir('langs'):
-            os.mkdir('langs')
-        os.symlink(os.environ['GTHOME'] + '/' + dirname, dirname, target_is_directory=True)
-    else:
-        print('\nGTHOME is set but there is no %s/%s; will have to build %s from scratch.\n' % (os.environ['GTHOME'], dirname, dirname))
-
-def get_data(depth, keep_going, skip_if_up_to_date, dep, skip):
-    org, lang = dep.split('-', 1)
-
-    if '-' in lang:
-        get_pair(depth, keep_going, skip_if_up_to_date, dep, skip)
-    else:
-        if org == 'giella':
-            maybe_symlink_GTHOME('langs/' + lang)
-            maybe_symlink_GTHOME('gtcore')
-            get_dep(depth, 'gtcore')
-            make_dep('gtcore')
-        if skip_if_up_to_date and is_dep_updated(dep):
-            print('Dependency %s is up-to-date, skipping update and build.\\n' % dep)
-        else:
-            try:
-                get_dep(depth, dep)
-                make_dep(dep)
-            except subprocess.CalledProcessError:
-                print('\nUnable to build %s\n' % dep)
-                if not keep_going:
-                    sys.exit(1)
-
-def list_pairs(modules):
-    for module in (modules or pmodules):
-        print('# Pairs in %s:' % module)
-        print('\n'.join(pr for pr in sorted(module_contents[module]) if '-' in pr))
-
-def list_language_modules(modules):
-    for module in (modules or lmodules):
-        print('# Language modules in %s:' % module)
-        print('\n'.join(lg for lg in sorted(module_contents[module]) if '-' not in lg))
 
 def check_for_git():
     try:
-        subprocess.run(['git', '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    except:
-        print('''
+        run(["git", "--version"], stdout=DEVNULL, stderr=DEVNULL)
+    except CalledProcessError:
+        print(
+            """
 
 You need to install git first!
 
@@ -225,37 +250,16 @@ If you use rpm/dnf, it's typically:
 
   sudo dnf install git
 
-''')
+"""
+        )
         sys.exit(1)
 
-def get_dep_name(name):
-    if name.startswith('giella-'):
-        lang = name.split('-', 1)[1]
-        if lang in giella_urls:
-            return name
-        else:
-            return None
-    elif name.startswith('apertium-'):
-        return get_dep_name(name.split('-', 1)[1])
-    elif '-' in name:
-        if name in pair_urls:
-            return 'apertium-' + name
-        alt = '-'.join(reversed(name.split('-')))
-        if alt in pair_urls:
-            print('\nWARNING: apertium-%s does not exist, using apertium-%s instead\n' % (name, alt))
-            return 'apertium-' + alt
-        else:
-            return None
-    else:
-        if name in lang_urls:
-            return 'apertium-' + name
-        else:
-            return None
 
 def main():
     check_for_git()
-    parser = argparse.ArgumentParser(description='Download and build Apertium pairs and language data.',
-        epilog='''EXAMPLES
+    parser = argparse.ArgumentParser(
+        description="Download and build Apertium pairs and language data.",
+        epilog="""EXAMPLES
        apertium-get nno-nob
 
        Download and set up apertium-nno-nob, along with its nno and
@@ -273,41 +277,99 @@ def main():
 
        apertium-get -l | grep kaz
 
-       List available language pairs involving Kazakh.''', formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-l', '--list', nargs='*', choices=pmodules, help='list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.', metavar='MODULES')
-    parser.add_argument('-m', '--modules', nargs='*', choices=lmodules, help='list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.', metavar='MODULES')
-    parser.add_argument('-k', '--keep-going', action='store_true', help='keep going even if a dependency fails.')
-    parser.add_argument('-s', '--skip-update', action='store_true', help="don't rebuild up-to-date dependencies/pairs")
-    parser.add_argument('-x', '--skip', action='append', nargs=1, help='skip data dependency DEP (useful if DEP is installed through a package manager); may be specified multiple times')
-    parser.add_argument('-d', '--depth', nargs=1, type=int, default=0, help="specify a --depth to 'git clone'")
-    parser.add_argument('pairs', nargs='*', help='pairs or modules to install')
+       List available language pairs involving Kazakh.""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-l",
+        "--list",
+        nargs="*",
+        choices=pmodules,
+        help="list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.",
+        metavar="MODULES",
+    )
+    parser.add_argument(
+        "-m",
+        "--modules",
+        nargs="*",
+        choices=lmodules,
+        help="list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.",
+        metavar="MODULES",
+    )
+    parser.add_argument(
+        "-k",
+        "--keep-going",
+        action="store_true",
+        help="keep going even if a dependency fails.",
+    )
+    parser.add_argument(
+        "-s",
+        "--skip-update",
+        action="store_true",
+        help="don't rebuild up-to-date dependencies/pairs",
+    )
+    parser.add_argument(
+        "-x",
+        "--skip",
+        action="append",
+        help="skip data dependency DEP (useful if DEP is installed through a package manager); may be specified multiple times",
+    )
+    parser.add_argument(
+        "-d", "--depth", type=int, default=0, help="specify a --depth to 'git clone'",
+    )
+    parser.add_argument("pairs", nargs="*", help="pairs or modules to install")
     args = parser.parse_args()
 
-    get_urls()
-
     if args.list != None:
-        list_pairs(args.list)
+        for module in args.list or pmodules:
+            list_pairs(module, True)
     elif args.modules != None:
-        list_language_modules(args.modules)
+        for module in args.modules or lmodules:
+            list_pairs(module, False)
     else:
         if len(args.pairs) == 0:
-            print('ERROR: No language pair specified.\n')
-            parser.print_help()
-            parser.exit(1)
+            parser.error("No language pair specified.\n")
         for arg in args.pairs:
-            dep = get_dep_name(arg)
-            if dep and '-' not in arg and get_dep_name('giella-' + arg):
-                print('\nWARNING: Both apertium-%s and giella-%s are available, defaulting to apertium-%s\n' % (arg, arg, arg))
-            if not dep and '-' not in arg:
-                dep = get_dep_name('giella-' + arg)
-            if not dep:
-                loc = 'SVN' if arg.startswith('giella-') else 'git'
-                print("\nWARNING: Couldn't find %s url for %s\n" % (loc, arg))
-                if args.keep_going:
-                    continue
-                else:
-                    parser.exit(1)
-            get_data(args.depth, args.keep_going, args.skip_update, dep, args.skip or [])
+            DEP_STATUS[normalize_name(arg)] = NOT_STARTED
+        for skip in args.skip or []:
+            DEP_STATUS[normalize_name(skip)] = SKIPPED
 
-if __name__ == '__main__':
+        # download requested repos
+        for dep in get_all_status(NOT_STARTED):
+            try_to_clone(dep, args.depth, args.keep_going)
+
+        # download dependencies
+        for dep in get_all_status(NOT_STARTED):
+            try_to_clone(dep, args.depth, args.keep_going)
+
+        # download giella-core and giella-shared if we need them
+        for dep in DEP_STATUS:
+            if dep.startswith("lang-"):
+                if "GIELLA_CORE" not in os.environ:
+                    try_to_clone("giella-core", args.depth, args.keep_going)
+                if "GIELLA_SHARED" not in os.environ:
+                    try_to_clone("giella-shared", args.depth, args.keep_going)
+                break
+
+        # update repos that were already downloaded
+        for dep in get_all_status(CLONED):
+            try:
+                update(dep, args.skip_update)
+            except CalledProcessError:
+                print("\nUnable to update directory of %s.\n" % dep)
+                error_on_dep(dep, args.keep_going)
+
+        # build everything
+        if DEP_STATUS.get("giella-core") == PULLED:
+            try_to_build("giella-core", args.keep_going)
+        if DEP_STATUS.get("giella-shared") == PULLED:
+            try_to_build("giella-shared", args.keep_going)
+        for dep in get_all_status(PULLED):
+            if len(dep.split("-")) == 2:
+                try_to_build(dep, args.keep_going)
+        for dep in get_all_status(PULLED):
+            try_to_build(dep, args.keep_going)
+
+
+if __name__ == "__main__":
     main()

--- a/apertium-get.py
+++ b/apertium-get.py
@@ -30,12 +30,12 @@ GIELLA_SHARED_GIT = "giellalt/giella-shared.git"
 
 
 class Status(Enum):
-    NOT_STARTED = auto()
-    CLONED = auto()
-    PULLED = auto()
-    DONE = auto()
-    SKIPPED = auto()
-    FAILED = auto()
+    NOT_STARTED = 0
+    CLONED = 1
+    PULLED = 2
+    DONE = 3
+    SKIPPED = 4
+    FAILED = 5
 
 
 dep_paths = {}

--- a/apertium-get.py
+++ b/apertium-get.py
@@ -13,7 +13,7 @@ from subprocess import (
     DEVNULL,
     CalledProcessError,
 )
-from enum import Enum, auto
+from enum import Enum
 
 ### Globals:
 

--- a/apertium-get.py
+++ b/apertium-get.py
@@ -127,7 +127,6 @@ def get_pair(depth, keep_going, skip_if_up_to_date, pair, skip):
     deps = []
     conf = open(pair + '/configure.ac')
     dep_list = ap_check_ling.findall(conf.read())
-    print('\n\n\nDEPS: %s' % dep_list)
     conf.close()
     for n, dep in dep_list:
         org, lang = dep.split('-', 1)

--- a/apertium-get.py
+++ b/apertium-get.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python3
+
+import requests, argparse, subprocess, os, re, sys
+
+### Globals:
+
+gitroot  = 'https://raw.githubusercontent.com/apertium'
+pmodules = ['trunk', 'staging', 'nursery', 'incubator']
+lmodules = ['languages', 'incubator']
+
+svnroot_giella = 'https://victorio.uit.no/langtech/trunk'
+
+pair_urls = {}
+lang_urls = {}
+giella_urls = {}
+module_contents = {}
+
+ap_check_ling = re.compile(r'AP_CHECK_LING\(\[(\d)\],\s+\[([\w-]+)\]\)', re.MULTILINE)
+# original pattern:
+# (awk -F'[][[:space:]]+' '/^ *AP_CHECK_LING\(/ && $2 && $4 {print $2, $4}' "${pair}"/configure.ac)
+
+def get_output(command, dirname=None):
+    return subprocess.check_output(command, cwd=dirname, stderr=subprocess.STDOUT,
+                                   universal_newlines=True)
+def run_command(command, dirname=None, env=None):
+    subprocess.check_call(command, cwd=dirname, stdout=None, stderr=None, env=env)
+
+def get_urls():
+    global pair_urls
+    global lang_urls
+    global giella_urls
+    global module_contents
+
+    for module in list(set(pmodules + lmodules)):
+        module_contents[module] = []
+        req = requests.get('%s/apertium-%s/master/.gitmodules' % (gitroot, module))
+        if req.status_code != 200:
+            #error?
+            continue
+        for ln in req.text.splitlines():
+            if ln.startswith('\turl = '):
+                url = ln.split()[-1]
+                code = url.split('apertium-')[-1][:-4]
+                # e.g. 'git@github.com:apertium/apertium-fin.git' -> 'fin'
+                if '-' in code:
+                    pair_urls[code] = url
+                else:
+                    lang_urls[code] = url
+                module_contents[module].append(code)
+    req = requests.get(svnroot_giella + '/langs/')
+    if req.status_code != 200:
+        #error?
+        return
+    for ln in req.text.splitlines():
+        if '<li><a' in ln and '..' not in ln:
+            code = ln.split('"')[1][:-1]
+            # e.g. '<li><a href="vot/">vot/</a></li>' -> 'vot'
+            url = svnroot_giella + '/langs/' + code
+            giella_urls[code] = url
+
+def dir_of_dep(dep):
+    if dep.startswith('giella-'):
+        return 'langs/' + dep[7:]
+    else:
+        return dep
+
+def bins_of_dep(dep):
+    if dep.startswith('giella-'):
+        return 'langs/%s/tools/mt/apertium' % dep[7:]
+    else:
+        return dep
+
+def make_dep(dep):
+    dirname = dir_of_dep(dep)
+    env = os.environ.copy()
+    env['GTHOME'] = os.getcwd()
+    env['GTCORE'] = os.getcwd() + '/gtcore'
+    # Let cwd be GTHOME from here on in; langs should exist under this dir:
+    print(dirname)
+    run_command(['./autogen.sh'], dirname, env)
+    if dep.startswith('giella-'):
+        run_command(['./configure', '--enable-apertium', '--with-hfst', '--enable-syntax'], dirname, env)
+        env['V'] = '1'
+        run_command(['make'], dirname, env)
+    elif dep == 'gtcore':
+        run_command(['./configure'], dirname, env)
+        run_command(['make', '-j3'], dirname, env)
+    else:
+        run_command(['make', '-j3'], dirname, env)
+
+def is_dep_updated(dep):
+    dirname = dir_of_dep(dep)
+    if os.path.isdir(dirname):
+        if os.path.isdir(dirname + '/.git'):
+            return get_output(['git', 'fetch', '--dry-run'], dirname) == ''
+        return get_output(['svn', 'status', '-qu', dirname]) == ''
+    return False
+
+def get_dep(depth, dep):
+    dirname = dir_of_dep(dep)
+    if os.path.isdir(dirname):
+        print('Updating existing %s (%s)' % (dirname, os.getcwd()))
+        cmd = ['svn', 'up']
+        if os.path.isdir(dirname + '/.git'):
+            cmd = ['git', 'pull']
+        run_command(cmd, dirname)
+    else:
+        if dep == 'gtcore':
+            run_command(['svn', 'checkout', svnroot_giella + '/gtcore', dirname])
+        if dep.startswith('giella-'):
+            url = giella_urls[dep.split('-', 1)[1]]
+            run_command(['svn', 'checkout', url, dirname])
+        else:
+            name = dirname.split('-', 1)[1]
+            url = pair_urls[name] if '-' in name else lang_urls[name]
+            cmd = ['git', 'clone']
+            if depth > 0:
+                cmd += ['--depth', str(depth)]
+            run_command(cmd + [url, dirname])
+
+def get_pair(depth, keep_going, skip_if_up_to_date, pair, skip):
+    if skip_if_up_to_date and is_dep_updated(pair):
+        print('Existing pair %s is already up to date. Skipping build step.' % pair)
+        return
+
+    get_dep(depth, pair)
+    deps = []
+    conf = open(pair + '/configure.ac')
+    dep_list = ap_check_ling.findall(conf.read())
+    print('\n\n\nDEPS: %s' % dep_list)
+    conf.close()
+    for n, dep in dep_list:
+        org, lang = dep.split('-', 1)
+        if lang in skip:
+            print('\nSkipping data %s as instructed.\n' % lang)
+        else:
+            deps.append((dep, n))
+
+    cmd = ['./autogen.sh']
+    for dep, n in deps:
+        try:
+            get_data(depth, skip_if_up_to_date, keep_going, dep, skip)
+        except subprocess.CalledProcessError:
+            print("\nWARNING: Couldn't get dependency %s; pair %s might not get set up correctly.\n" % (dep, pair))
+            if keep_going:
+                print('WARNING: Continuing on as if nothing happened ...\n')
+            else:
+                sys.exit(1)
+        binsdir = bins_of_dep(dep)
+        cmd.append('--with-lang%s=../%s' % (n, binsdir))
+
+    run_command(cmd, dirname=pair)
+    run_command(['make', '-j3'], dirname=pair)
+    try:
+        subprocess.check_call(['make', 'test'], cwd=pair, stdout=None, stderr=None)
+    except subprocess.CalledProcessError:
+        print("make test failed, but that's probably fine.")
+
+    print('''
+
+All done!
+
+You can now "cd ${pair}" or one of the dependencies, edit some files
+and type "make -j3 langs" to compile again.
+
+''')
+
+def maybe_symlink_GTHOME(dirname):
+    if os.path.isdir(dirname):
+        print('\nFound %s here, using that.\n' % dirname)
+    elif 'GTHOME' not in os.environ:
+        print('\nGTHOME unset; will have to build %s without it.\n' % dirname)
+    elif os.path.isdir(os.environ['GTHOME'] + '/' + dirname):
+        print('Found %s in your $GTHOME, symlinking to that to avoid recompilation.\n' % dirname)
+        if not os.path.isdir('langs'):
+            os.mkdir('langs')
+        os.symlink(os.environ['GTHOME'] + '/' + dirname, dirname, target_is_directory=True)
+    else:
+        print('\nGTHOME is set but there is no %s/%s; will have to build %s from scratch.\n' % (os.environ['GTHOME'], dirname, dirname))
+
+def get_data(depth, keep_going, skip_if_up_to_date, dep, skip):
+    org, lang = dep.split('-', 1)
+
+    if '-' in lang:
+        get_pair(depth, keep_going, skip_if_up_to_date, dep, skip)
+    else:
+        if org == 'giella':
+            maybe_symlink_GTHOME('langs/' + lang)
+            maybe_symlink_GTHOME('gtcore')
+            get_dep(depth, 'gtcore')
+            make_dep('gtcore')
+        if skip_if_up_to_date and is_dep_updated(dep):
+            print('Dependency %s is up-to-date, skipping update and build.\\n' % dep)
+        else:
+            try:
+                get_dep(depth, dep)
+                make_dep(dep)
+            except subprocess.CalledProcessError:
+                print('\nUnable to build %s\n' % dep)
+                if not keep_going:
+                    sys.exit(1)
+
+def list_pairs(modules):
+    for module in (modules or pmodules):
+        print('# Pairs in %s:' % module)
+        print('\n'.join(pr for pr in sorted(module_contents[module]) if '-' in pr))
+
+def list_language_modules(modules):
+    for module in (modules or lmodules):
+        print('# Language modules in %s:' % module)
+        print('\n'.join(lg for lg in sorted(module_contents[module]) if '-' not in lg))
+
+def check_for_git():
+    try:
+        subprocess.run(['git', '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except:
+        print('''
+
+You need to install git first!
+
+If you use apt-get, it's typically:
+
+  sudo apt-get install git
+
+If you use rpm/dnf, it's typically:
+
+  sudo dnf install git
+
+''')
+        sys.exit(1)
+
+def get_dep_name(name):
+    if name.startswith('giella-'):
+        lang = name.split('-', 1)[1]
+        if lang in giella_urls:
+            return name
+        else:
+            return None
+    elif name.startswith('apertium-'):
+        return get_dep_name(name.split('-', 1)[1])
+    elif '-' in name:
+        if name in pair_urls:
+            return 'apertium-' + name
+        alt = '-'.join(reversed(name.split('-')))
+        if alt in pair_urls:
+            print('\nWARNING: apertium-%s does not exist, using apertium-%s instead\n' % (name, alt))
+            return 'apertium-' + alt
+        else:
+            return None
+    else:
+        if name in lang_urls:
+            return 'apertium-' + name
+        else:
+            return None
+
+def main():
+    check_for_git()
+    parser = argparse.ArgumentParser(description='Download and build Apertium pairs and language data.',
+        epilog='''EXAMPLES
+       apertium-get nno-nob
+
+       Download and set up apertium-nno-nob, along with its nno and
+       nob dependencies.
+
+       sudo apt-get install giella-sme
+       apertium-get -x sme sme-nob
+
+       Install giella-sme through apt-get, then install download and set
+       up apertium-sme-nob, along with the nob dependency (but not sme).
+
+       apertium-get -l trunk
+
+       List available language pairs in SVN trunk.
+
+       apertium-get -l | grep kaz
+
+       List available language pairs involving Kazakh.''', formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('-l', '--list', nargs='*', choices=pmodules, help='list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.', metavar='MODULES')
+    parser.add_argument('-m', '--modules', nargs='*', choices=lmodules, help='list available pairs in MODULES instead of setting up data. If no modules are specified, all pairs will be listed.', metavar='MODULES')
+    parser.add_argument('-k', '--keep-going', action='store_true', help='keep going even if a dependency fails.')
+    parser.add_argument('-s', '--skip-update', action='store_true', help="don't rebuild up-to-date dependencies/pairs")
+    parser.add_argument('-x', '--skip', action='append', nargs=1, help='skip data dependency DEP (useful if DEP is installed through a package manager); may be specified multiple times')
+    parser.add_argument('-d', '--depth', nargs=1, type=int, default=0, help="specify a --depth to 'git clone'")
+    parser.add_argument('pairs', nargs='*', help='pairs or modules to install')
+    args = parser.parse_args()
+
+    get_urls()
+
+    if args.list != None:
+        list_pairs(args.list)
+    elif args.modules != None:
+        list_language_modules(args.modules)
+    else:
+        if len(args.pairs) == 0:
+            print('ERROR: No language pair specified.\n')
+            parser.print_help()
+            parser.exit(1)
+        for arg in args.pairs:
+            dep = get_dep_name(arg)
+            if dep and '-' not in arg and get_dep_name('giella-' + arg):
+                print('\nWARNING: Both apertium-%s and giella-%s are available, defaulting to apertium-%s\n' % (arg, arg, arg))
+            if not dep and '-' not in arg:
+                dep = get_dep_name('giella-' + arg)
+            if not dep:
+                loc = 'SVN' if arg.startswith('giella-') else 'git'
+                print("\nWARNING: Couldn't find %s url for %s\n" % (loc, arg))
+                if args.keep_going:
+                    continue
+                else:
+                    parser.exit(1)
+            get_data(args.depth, args.keep_going, args.skip_update, dep, args.skip or [])
+
+if __name__ == '__main__':
+    main()

--- a/t/tests.sh
+++ b/t/tests.sh
@@ -31,7 +31,7 @@ echo "Full module listing should be fairly big …"
 echo "Try to set up nno-nob with --depth 1 …"
 (
     cd "${tmp}"
-    "${prog}" -x foo -x bar -d 1 nno-nob 2>&1
+    "${prog}" -x foo -x bar -d 1 -H nno-nob 2>&1
     cd apertium-nno-nob
     make test >&2
 ) > nno-nob.log || ( cat nno-nob.log; exit 1 )
@@ -39,13 +39,13 @@ echo "Try to set up nno-nob with --depth 1 …"
 echo "Try to set up nno-nob again (skipping build) …"
 (
     cd "${tmp}"
-    "${prog}" -s nno-nob 2>&1 | grep -i skipping
+    "${prog}" -s -H nno-nob 2>&1 | grep -i skipping
 ) > nno-nob.2.log || ( cat nno-nob.2.log; exit 1 )
 
 echo "Try to set up fr-es …"
 (
     cd "${tmp}"
-    "${prog}" fr-es 2>&1
+    "${prog}" -H fr-es 2>&1
     cd apertium-fr-es
     make test >&2
 ) > fr-es.log || ( cat fr-es.log; exit 1 )
@@ -53,5 +53,5 @@ echo "Try to set up fr-es …"
 echo "Try to set up ibo …"
 (
     cd "${tmp}"
-    "${prog}" ibo 2>&1
+    "${prog}" -H ibo 2>&1
 ) > ibo.log || ( cat ibo.log; exit 1 )

--- a/t/tests.sh
+++ b/t/tests.sh
@@ -9,7 +9,7 @@ canonpath () {
     # OS X doesn't have realpath :-/
     realpath "$1" 2>/dev/null || greadlink -f "$1" 2>/dev/null || ( cd "$(dirname "$1")" && echo "$(pwd)"/"$(basename "$1")")
 }
-prog=$(canonpath ../apertium-get)
+prog=$(canonpath ../apertium-get.py)
 
 tmp=$(mktemp -d -t apertium-get.XXXXXXXXXXX)
 trap 'rm -rf "${tmp}"' EXIT
@@ -17,7 +17,7 @@ trap 'rm -rf "${tmp}"' EXIT
 
 # TESTS:
 echo "Show help …"
-diff <("${prog}" -? 2>&1) unarg.expected
+diff <("${prog}" -h 2>&1) unarg.expected
 
 echo "List trunk …"
 diff <("${prog}" -l trunk) trunk.expected

--- a/t/tests.sh
+++ b/t/tests.sh
@@ -31,7 +31,7 @@ echo "Full module listing should be fairly big …"
 echo "Try to set up nno-nob with --depth 1 …"
 (
     cd "${tmp}"
-    "${prog}" -x foo -x bar -d 1 -H nno-nob 2>&1
+    "${prog}" -x foo -x bar -d 1 nno-nob 2>&1
     cd apertium-nno-nob
     make test >&2
 ) > nno-nob.log || ( cat nno-nob.log; exit 1 )
@@ -39,13 +39,13 @@ echo "Try to set up nno-nob with --depth 1 …"
 echo "Try to set up nno-nob again (skipping build) …"
 (
     cd "${tmp}"
-    "${prog}" -s -H nno-nob 2>&1 | grep -i skipping
+    "${prog}" -s nno-nob 2>&1 | grep -i skipping
 ) > nno-nob.2.log || ( cat nno-nob.2.log; exit 1 )
 
 echo "Try to set up fr-es …"
 (
     cd "${tmp}"
-    "${prog}" -H fr-es 2>&1
+    "${prog}" fr-es 2>&1
     cd apertium-fr-es
     make test >&2
 ) > fr-es.log || ( cat fr-es.log; exit 1 )
@@ -53,5 +53,5 @@ echo "Try to set up fr-es …"
 echo "Try to set up ibo …"
 (
     cd "${tmp}"
-    "${prog}" -H ibo 2>&1
+    "${prog}" ibo 2>&1
 ) > ibo.log || ( cat ibo.log; exit 1 )

--- a/t/trunk.expected
+++ b/t/trunk.expected
@@ -13,7 +13,6 @@ srd-ita
 spa-ita
 eo-es
 rus-ukr
-pt-ca
 dan-nor
 oc-es
 bel-rus
@@ -51,4 +50,5 @@ cat-ita
 pol-szl
 eng-spa
 ron-cat
-
+por-cat
+oci-fra

--- a/t/unarg.expected
+++ b/t/unarg.expected
@@ -1,6 +1,6 @@
 usage: apertium-get.py [-h] [-l [MODULES [MODULES ...]]]
                        [-m [MODULES [MODULES ...]]] [-k] [-s] [-x SKIP]
-                       [-d DEPTH]
+                       [-d DEPTH] [-S]
                        [pairs [pairs ...]]
 
 Download and build Apertium pairs and language data.
@@ -25,6 +25,7 @@ optional arguments:
                         times
   -d DEPTH, --depth DEPTH
                         specify a --depth to 'git clone'
+  -S, --ssh             use ssh urls in git clone rather than https
 
 EXAMPLES
        apertium-get nno-nob

--- a/t/unarg.expected
+++ b/t/unarg.expected
@@ -1,29 +1,30 @@
-ERROR: Invalid option: -?
+usage: apertium-get.py [-h] [-l [MODULES [MODULES ...]]]
+                       [-m [MODULES [MODULES ...]]] [-k] [-s] [-x SKIP]
+                       [-d DEPTH]
+                       [pairs [pairs ...]]
 
-USAGE
-       apertium-get PAIR
-       apertium-get -l [MODULE...]
+Download and build Apertium pairs and language data.
 
-DESCRIPTION
-       Run with just one argument, it will download and set up the
-       Apertium development data for the specified language pair.
+positional arguments:
+  pairs                 pairs or modules to install
 
-       With the -l option, it will list available language pairs. Give
-       one or more MODULE arguments to list only pairs in that SVN
-       module (one of "trunk", "staging", "nursery", "incubator").
-       The same behavior can be invoked for language modules using -m.
-
-OPTIONS
-       -h          display this help and exit
-       -l          list available packages instead of setting up data
-       -m          list available language modules instead of setting up
-                   data
-       -k          keep going even if a dependency fails
-       -s          skip the build step for up-to-date dependencies/pairs
-       -x DEP      skip data dependency DEP (useful if DEP is installed
-                   through a package manager); may be specified multiple
-                   times
-       -d DEPTH    specify a --depth to 'git clone'
+optional arguments:
+  -h, --help            show this help message and exit
+  -l [MODULES [MODULES ...]], --list [MODULES [MODULES ...]]
+                        list available pairs in MODULES instead of setting up
+                        data. If no modules are specified, all pairs will be
+                        listed.
+  -m [MODULES [MODULES ...]], --modules [MODULES [MODULES ...]]
+                        list available pairs in MODULES instead of setting up
+                        data. If no modules are specified, all pairs will be
+                        listed.
+  -k, --keep-going      keep going even if a dependency fails.
+  -s, --skip-update     don't rebuild up-to-date dependencies/pairs
+  -x SKIP, --skip SKIP  skip data dependency DEP (useful if DEP is installed
+                        through a package manager); may be specified multiple
+                        times
+  -d DEPTH, --depth DEPTH
+                        specify a --depth to 'git clone'
 
 EXAMPLES
        apertium-get nno-nob


### PR DESCRIPTION
This PR is a port of `apertium-get` to Python. It should have roughly equivalent behavior, though it will correct wrongly ordered pairs, so `apertium-get.py eng-ind` will download `apertium-ind-eng`.

Note that all of the Giella functionality is identical to the bash version and is thus equally broken by the move to Github. It would probably be reasonable to wait until everything is figured out regarding that, at which point I can update this PR.